### PR TITLE
Added theme colors for GitHub Activity Calendar

### DIFF
--- a/components/github-activity/GithubActivity.tsx
+++ b/components/github-activity/GithubActivity.tsx
@@ -1,13 +1,22 @@
 import React from 'react'
+import { ThemeInput } from 'react-activity-calendar'
 import GitHubCalendar from 'react-github-calendar'
 
 import styles from './styles.module.sass'
+
+const explicitTheme: ThemeInput = {
+    light: ['#f0f0f0', '#c4edde', '#7ac7c4', '#f73859', '#384259'],
+    dark: ['#1b1b1b', '#524508', '#6C590A', '#867C0C', '#FFC107']
+}
 
 export const GithubActivity: React.FC = () => {
     return (
         <section className={styles.activitySection}>
             <h2 className={'pageTitle'}>{'Work activity'}</h2>
-            <GitHubCalendar username={'miksrv'} />
+            <GitHubCalendar
+                username={'miksrv'}
+                theme={explicitTheme}
+            />
         </section>
     )
 }


### PR DESCRIPTION
<img width="838" alt="Screenshot 2024-09-24 at 2 56 27 PM" src="https://github.com/user-attachments/assets/ddfa62ca-a9a4-44b0-b9f4-d049a82f03fd">
