### PR TITLE
Load Yandex.Metrika with next/script

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { AppProps } from 'next/app'
 import Head from 'next/head'
+import Script from 'next/script'
 
 import { Header, PrintResume, StarField } from '@/components'
 import { DataProvider } from '@/utils'
@@ -88,11 +89,38 @@ const App = ({ Component, pageProps }: AppProps) => {
             </DataProvider>
 
             {process.env.NODE_ENV === 'production' && (
-                <div
-                    dangerouslySetInnerHTML={{
-                        __html: '<!-- Yandex.Metrika counter --> <script type="text/javascript" > (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)}; m[i].l=1*new Date(); for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }} k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)}) (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym"); ym(67613284, "init", { clickmap:true, trackLinks:true, accurateTrackBounce:true }); </script> <noscript><div><img src="https://mc.yandex.ru/watch/67613284" style="position:absolute; left:-9999px;" alt="" /></div></noscript> <!-- /Yandex.Metrika counter -->'
-                    }}
-                />
+                <>
+                    {/* Yandex.Metrika counter */}
+                    <Script
+                        id={'yandex-metrika'}
+                        strategy={'afterInteractive'}
+                    >
+                        {`
+                            (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+                            m[i].l=1*new Date();
+                            for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+                            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+                            (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+
+                            ym(67613284, "init", {
+                                clickmap:true,
+                                referrer: document.referrer,
+                                url: location.href,
+                                accurateTrackBounce:true,
+                                trackLinks:true
+                            });
+                        `}
+                    </Script>
+                    <noscript>
+                        <div>
+                            <img
+                                src={'https://mc.yandex.ru/watch/67613284'}
+                                style={{ position: 'absolute', left: '-9999px' }}
+                                alt={''}
+                            />
+                        </div>
+                    </noscript>
+                </>
             )}
         </>
     )


### PR DESCRIPTION
Replace raw dangerouslySetInnerHTML analytics blob with Next.js Script and a noscript fallback. Adds import of next/script, wraps the Yandex.Metrika initializer in a <Script> using afterInteractive strategy, sets an id, and includes referrer and url in the init options. Keeps the production-only check and provides the noscript image fallback with inline positioning.