### PR TITLE
Add smooth scroll handler and update URL hash

### DIFF
--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -65,7 +65,19 @@ export const Header: React.FC = () => {
         }
     }, [isMenuOpen])
 
-    const handleLinkClick = () => setIsMenuOpen(false)
+    const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, url: string) => {
+        e.preventDefault()
+        const targetId = url.replace('#', '')
+        const targetElement = document.getElementById(targetId)
+
+        if (targetElement) {
+            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            // Update URL hash without triggering browser scroll
+            window.history.pushState(null, '', url)
+        }
+
+        setIsMenuOpen(false)
+    }
 
     return (
         <header
@@ -80,6 +92,7 @@ export const Header: React.FC = () => {
                             key={link.url}
                             href={link.url}
                             className={activeSection === link.url.replace('#', '') ? styles.active : undefined}
+                            onClick={(e) => handleNavClick(e, link.url)}
                         >
                             {link.label}
                         </a>
@@ -125,7 +138,7 @@ export const Header: React.FC = () => {
                                 key={link.url}
                                 href={link.url}
                                 className={activeSection === link.url.replace('#', '') ? styles.active : undefined}
-                                onClick={handleLinkClick}
+                                onClick={(e) => handleNavClick(e, link.url)}
                             >
                                 {link.label}
                             </a>

--- a/styles/globals.sass
+++ b/styles/globals.sass
@@ -1,7 +1,6 @@
 @use 'variables' as variables
 
 html
-    scroll-behavior: smooth
     scroll-padding-top: 60px
 
 // ── Skip-to-content link ───────────────────────────────


### PR DESCRIPTION
Replace the simple link-close handler with handleNavClick that prevents the default anchor jump, smoothly scrolls to the target element via scrollIntoView, updates the URL hash with history.pushState (avoiding a browser-triggered scroll), and closes the mobile menu. Attach this handler to header navigation links. Remove the global CSS scroll-behavior to avoid conflicting/default browser jumps and rely on the JS-driven smooth scrolling instead.