### PR TITLE
Remove framer-motion and refine scrolling

### DIFF
--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -68,14 +68,19 @@ export const Header: React.FC = () => {
     const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, url: string) => {
         e.preventDefault()
         const targetId = url.replace('#', '')
-        const targetElement = document.getElementById(targetId)
 
-        if (targetElement) {
-            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
-            // Update URL hash without triggering browser scroll
-            window.history.pushState(null, '', url)
+        // For intro/about section, scroll to the very top
+        if (targetId === 'intro') {
+            window.scrollTo({ behavior: 'smooth', top: 0 })
+        } else {
+            const targetElement = document.getElementById(targetId)
+            if (targetElement) {
+                targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            }
         }
 
+        // Update URL hash without triggering browser scroll
+        window.history.pushState(null, '', url)
         setIsMenuOpen(false)
     }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { motion, Variants } from 'framer-motion'
 
 import { type GetStaticProps } from 'next'
 import dynamic from 'next/dynamic'
@@ -36,11 +35,6 @@ const GithubCalendar = dynamic(() => import('@/components/github-calendar/Github
     ssr: false
 })
 
-const sectionVariants: Variants = {
-    hidden: { opacity: 0, y: 40 },
-    visible: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.25, 0.1, 0.25, 1] } }
-}
-
 type MainPageProps = {
     githubData: GithubData
 }
@@ -74,14 +68,10 @@ const MainPage: React.FC<MainPageProps> = ({ githubData }) => {
             </div>
 
             {/* ── GitHub Activity ─────────────────────────────────────── */}
-            <motion.div
+            <div
                 id={'activity'}
                 className={styles.sectionBlock}
                 aria-label={'GitHub Activity'}
-                initial={'hidden'}
-                whileInView={'visible'}
-                viewport={{ once: true, amount: 0.08 }}
-                variants={sectionVariants}
             >
                 <section>
                     <h2 className={'pageTitle'}>{data?.seo?.activity?.title}</h2>
@@ -92,17 +82,13 @@ const MainPage: React.FC<MainPageProps> = ({ githubData }) => {
                 <GithubLanguages />
                 <GithubSparkline />
                 <GithubRepos />
-            </motion.div>
+            </div>
 
             {/* ── Projects ────────────────────────────────────────────── */}
-            <motion.div
+            <div
                 id={'projects'}
                 className={styles.sectionBlock}
                 aria-label={'Projects'}
-                initial={'hidden'}
-                whileInView={'visible'}
-                viewport={{ once: true, amount: 0.08 }}
-                variants={sectionVariants}
             >
                 <section>
                     <h2 className={'pageTitle'}>{data?.seo?.projects?.title}</h2>
@@ -110,17 +96,13 @@ const MainPage: React.FC<MainPageProps> = ({ githubData }) => {
                 </section>
 
                 <Projects />
-            </motion.div>
+            </div>
 
             {/* ── Experience ──────────────────────────────────────────── */}
-            <motion.div
+            <div
                 id={'experience'}
                 className={styles.sectionBlock}
                 aria-label={'Experience'}
-                initial={'hidden'}
-                whileInView={'visible'}
-                viewport={{ once: true, amount: 0.04 }}
-                variants={sectionVariants}
             >
                 <section className={styles.sectionHeader}>
                     <div>
@@ -130,16 +112,12 @@ const MainPage: React.FC<MainPageProps> = ({ githubData }) => {
                 </section>
 
                 <Experience />
-            </motion.div>
+            </div>
 
             {/* ── Skills ──────────────────────────────────────────────── */}
-            <motion.div
+            <div
                 id={'skills'}
                 className={styles.sectionBlock}
-                initial={'hidden'}
-                whileInView={'visible'}
-                viewport={{ once: true, amount: 0.04 }}
-                variants={sectionVariants}
             >
                 <section>
                     <h2 className={'pageTitle'}>{data?.seo?.skills?.title}</h2>
@@ -149,19 +127,15 @@ const MainPage: React.FC<MainPageProps> = ({ githubData }) => {
                 <SkillsCloud />
 
                 <Skills />
-            </motion.div>
+            </div>
 
             {/* ── Contact ─────────────────────────────────────────────── */}
-            <motion.div
+            <div
                 id={'contact'}
                 className={styles.sectionBlock}
-                initial={'hidden'}
-                whileInView={'visible'}
-                viewport={{ once: true, amount: 0.1 }}
-                variants={sectionVariants}
             >
                 <Contact />
-            </motion.div>
+            </div>
         </GithubDataProvider>
     )
 }

--- a/styles/globals.sass
+++ b/styles/globals.sass
@@ -1,7 +1,7 @@
 @use 'variables' as variables
 
 html
-    scroll-padding-top: 60px
+    scroll-padding-top: 30px
 
 // ── Skip-to-content link ───────────────────────────────
 .skipLink


### PR DESCRIPTION
Drop framer-motion-based section animations in pages/index.tsx by replacing motion.divs with plain divs and removing the variants and import. Update Header.handleNavClick to special-case the 'intro' hash (smooth scroll to top) and only update the URL hash after scrolling logic. Reduce global html scroll-padding-top from 60px to 30px to better align anchored scroll positions.